### PR TITLE
Fetch current user through API

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,21 @@
 class SessionsController < ApplicationController
+  before_action :require_login, only: :show
+
+  def show
+    render json: current_user_info
+  end
+
   def create
     user_data = GroupMe::User.find(access_token)
     user = find_or_create_user(user_data)
     sign_in(user)
     redirect_to root_path
+  end
+
+  private
+
+  def access_token
+    params[:access_token]
   end
 
   def find_or_create_user(user_data)
@@ -17,7 +29,7 @@ class SessionsController < ApplicationController
       )
   end
 
-  def access_token
-    params[:access_token]
+  def current_user_info
+    { name: current_user.name, access_token: current_user.access_token }
   end
 end

--- a/app/javascript/packs/index.js
+++ b/app/javascript/packs/index.js
@@ -3,7 +3,7 @@ import { Elm } from '../Main.elm';
 document.addEventListener('DOMContentLoaded', () => {
   Elm.Main.init({
     node: document.getElementById('main'),
-    flags: { token: process.env.API_TOKEN, clientId: process.env.CLIENT_ID  }
+    flags: { clientId: process.env.CLIENT_ID  }
   });
 })
 

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,4 +1,5 @@
 Clearance.configure do |config|
   config.mailer_sender = "reply@example.com"
   config.rotate_csrf_on_sign_in = true
+  config.routes = false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resource :sessions, only: :show
   get 'auth/callback', to: 'sessions#create'
   root to: 'application#index'
 end


### PR DESCRIPTION
This commit updates how the current user and their access token are
passed into the front end.

Instead of passing in an access token from a hard-coded environment
variable, the access token is now retrieved from the current user. This
is facilitated by a new sign-in-protected route that returns the current
user when present.

On the front end, two new variants were added to the `Model`: `Loading` and
`SignIn`.

`Loading` is used as a transition state when various API requests are
being made.

`SignIn` is the initial state of the application. The `Model` is also set to
`SignIn` when actions that required a current user take place. When the
`Model` is set to `SignIn`, the sign in link to GroupMe is displayed.