### PR TITLE
Refactor GroupMe::User with method_missing

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,18 +1,18 @@
 class SessionsController < ApplicationController
   def create
-    user_data = GroupMe::User.find(access_token)
+    user_data = GroupMe::User.new.find(access_token)
     user = find_or_create_user(user_data)
     sign_in(user)
     redirect_to root_path
   end
 
   def find_or_create_user(user_data)
-    User.find_by(id: user_data['id']) ||
+    User.find_by(id: user_data.id) ||
       User.create(
-        id: user_data['id'],
-        name: user_data['name'],
-        email: user_data['email'],
-        image_url: user_data['image_url'],
+        id: user_data.id,
+        name: user_data.name,
+        email: user_data.email,
+        image_url: user_data.image_url,
         access_token: access_token
       )
   end

--- a/app/models/group_me/base.rb
+++ b/app/models/group_me/base.rb
@@ -15,11 +15,5 @@ module GroupMe
 
       super
     end
-
-    private
-
-    def current_user_url(access_token)
-      "#{BASE_API_URL}/users/me?token=#{access_token}"
-    end
   end
 end

--- a/app/models/group_me/base.rb
+++ b/app/models/group_me/base.rb
@@ -1,0 +1,25 @@
+module GroupMe
+  BASE_API_URL = "https://api.groupme.com/v3".freeze
+
+  class Base
+    attr_accessor :data
+
+    def respond_to_missing?
+      true
+    end
+
+    def method_missing(method, *args, &block)
+      if data.keys.include?(method.to_s)
+        return data[method.to_s]
+      end
+
+      super
+    end
+
+    private
+
+    def current_user_url(access_token)
+      "#{BASE_API_URL}/users/me?token=#{access_token}"
+    end
+  end
+end

--- a/app/models/group_me/user.rb
+++ b/app/models/group_me/user.rb
@@ -1,13 +1,14 @@
 require 'net/http'
 
 module GroupMe
-  class User
-    def self.find(access_token)
-      uri = URI("https://api.groupme.com/v3/users/me?token=#{access_token}")
+  class User < Base
+    def find(access_token)
+      uri = URI(current_user_url(access_token))
       response = Net::HTTP.get_response(uri)
 
       if response.code == '200'
-        JSON.parse(response.body)['response']
+        self.data = JSON.parse(response.body)['response']
+        self
       end
     end
   end

--- a/app/models/group_me/user.rb
+++ b/app/models/group_me/user.rb
@@ -11,5 +11,11 @@ module GroupMe
         self
       end
     end
+
+    private
+
+    def current_user_url(access_token)
+      "#{BASE_API_URL}/users/me?token=#{access_token}"
+    end
   end
 end


### PR DESCRIPTION
This refactor adds a new parent `GroupMe::Base` class which
`GroupMe::User` inherits from. The new base object takes advantage of
method_missing so one can use method calls to access the data returned
by the GroupMe API. So instead of:

```ruby
api_data['email']
```

One can use:

```ruby
api_data.email
```

This commit also extracts out some functionality for building the GroupMe API URLs into the new base class.