### PR TITLE
Add Message model and code for fetching messages

### DIFF
--- a/app/controllers/message_caches_controller.rb
+++ b/app/controllers/message_caches_controller.rb
@@ -1,0 +1,34 @@
+class MessageCachesController < ApplicationController
+  before_action :require_login
+  before_action :require_group_membership
+
+  def show
+    render json: MessageCache.where(group_id: group_id).last
+  end
+
+  def create
+    message_cache = MessageCache.new(
+      started_at: Time.current,
+      group_id: group_id,
+      started_by: current_user
+    )
+
+    if message_cache.save
+      head :ok
+    else
+      render json: message_cache.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def require_group_membership
+    unless current_user.group_member?(group_id)
+      head :unauthorized
+    end
+  end
+
+  def group_id
+    params[:group_id]
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :require_login
 
   def index
-    if current_user.group_ids.include?(params[:group_id])
+    if current_user.member?(params[:group_id])
       render json: Message.where(group_id: params[:group_id]).limit(20)
     else
       head :unauthorized

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,11 @@
+class MessagesController < ApplicationController
+  before_action :require_login
+
+  def index
+    if current_user.group_ids.include?(params[:group_id])
+      render json: Message.where(group_id: params[:group_id]).limit(20)
+    else
+      head :unauthorized
+    end
+  end
+end

--- a/app/controllers/most_liked_messages_controller.rb
+++ b/app/controllers/most_liked_messages_controller.rb
@@ -1,0 +1,13 @@
+class MostLikedMessagesController < ApplicationController
+  before_action :require_login
+
+  def index
+    if current_user.group_ids.include?(params[:group_id])
+      limit = params[:limit] || 10
+
+      render json: Message.where(group_id: group_id).by_favorite_count.limit(limit)
+    else
+      head :unauthorized
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
   def create
     user_data = GroupMe::User.new.find(access_token)
     user = find_or_create_user(user_data)
-    find_or_create_groups
+    find_or_create_groups(user)
 
     sign_in(user)
     redirect_to root_path
@@ -31,8 +31,9 @@ class SessionsController < ApplicationController
       )
   end
 
-  def find_or_create_groups
+  def find_or_create_groups(user)
     groups = GroupMe::FetchGroups.perform(access_token)
+    user.update(group_ids: groups.map(&:id))
     group_data = groups.map do |group|
       {
         id: group.id,

--- a/app/jobs/message_cache_job.rb
+++ b/app/jobs/message_cache_job.rb
@@ -1,0 +1,32 @@
+class MessageCacheJob < ApplicationJob
+  def perform(message_cache_id, access_token)
+    message_cache = MessageCache.find(message_cache_id)
+    group = message_cache.group
+
+    messages = GroupMe::FetchMessages.perform(access_token, group.id, group.last_message_id)
+    insert_messages(messages)
+    message_cache.update(ended_at: Time.current)
+  end
+
+  private
+
+  def insert_messages(messages)
+    message_data = messages.map do |message|
+      {
+        id: message.id,
+        group_id: message.group_id,
+        user_id: message.user_id,
+        avatar_url: message.avatar_url,
+        text: message.text,
+        favorited_by: message.favorited_by,
+        favorites_count: message.favorited_by.size,
+        attachments: message.attachments,
+        raw_message: message.data,
+        created_at: Time.at(message.created_at).to_datetime,
+        updated_at: Time.at(message.updated_at).to_datetime
+      }
+
+    end
+    Message.upsert_all(message_data)
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,2 +1,12 @@
 class Group < ApplicationRecord
+  has_many :message_caches
+  has_many :messages
+
+  def last_message_id
+    messages.order(created_at: :desc).first&.id
+  end
+
+  def messages_last_fetched_at
+    message_caches.last&.ended_at
+  end
 end

--- a/app/models/group_me/fetch_messages.rb
+++ b/app/models/group_me/fetch_messages.rb
@@ -1,0 +1,34 @@
+require 'net/http'
+
+module GroupMe
+  class FetchMessages < Base
+    attr_accessor :group_id
+
+    def self.perform(access_token, group_id)
+      @group_id = group_id
+      new.perform(access_token, 1, [])
+    end
+
+    def perform(access_token, page, acc = [])
+      uri = URI(messages_url(access_token, page))
+      response = Net::HTTP.get_response(uri)
+
+      if response.code == '200'
+        message_data = JSON.parse(response.body)['response']
+
+        if message_data.empty?
+          acc
+        else
+          messages = message_data.map { |message| Message.new(message) }
+          perform(access_token, page + 1, acc + messages)
+        end
+      end
+    end
+
+    private
+
+    def messages_url(access_token, page)
+      "#{BASE_API_URL}/groups/#{group_id}/messages?token=#{access_token}&page=#{page}&limit=100"
+    end
+  end
+end

--- a/app/models/group_me/message.rb
+++ b/app/models/group_me/message.rb
@@ -1,0 +1,7 @@
+module GroupMe
+  class Message < Base
+    def initialize(data)
+      self.data = data
+    end
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,8 @@
 class Message < ApplicationRecord
   before_save :update_favorites_count
 
+  scope :by_favorite_count, -> { order(favorites_count: :desc) }
+
   private
 
   def update_favorites_count

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
+  belongs_to :group
+
   before_save :update_favorites_count
 
   scope :by_favorite_count, -> { order(favorites_count: :desc) }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,9 @@
+class Message < ApplicationRecord
+  before_save :update_favorites_count
+
+  private
+
+  def update_favorites_count
+    self.favorites_count = favorited_by.size
+  end
+end

--- a/app/models/message_cache.rb
+++ b/app/models/message_cache.rb
@@ -1,0 +1,42 @@
+class MessageCache < ApplicationRecord
+  belongs_to :started_by, class_name: 'User'
+  belongs_to :group
+
+  validates :started_at, :started_by, :group, presence: true
+  validate :start_time_not_in_future
+  validate :end_time_after_start_time
+  validate :one_cache_per_day_per_group, on: :create
+
+  after_create :enqueue_cache_job
+
+  scope :for_last_day, -> { where("started_at >= ?", 24.hours.ago) }
+  scope :running, -> { where(ended_at: nil) }
+
+  def ended?
+    ended_at.present? && ended_at <= Time.current
+  end
+
+  private
+
+  def start_time_not_in_future
+    return if started_at <= Time.current
+
+    errors.add(:started_at, "must be in the past")
+  end
+
+  def end_time_after_start_time
+    return if ended_at.nil? || ended_at > started_at
+
+    errors.add(:ended_at, "must be after started_at")
+  end
+
+  def one_cache_per_day_per_group
+    return unless group.message_caches.for_last_day.exists?
+
+    errors.add(:group, "can only cache messages once per day")
+  end
+
+  def enqueue_cache_job
+    MessageCacheJob.perform_later(id, started_by.access_token)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ApplicationRecord
   def skip_password_validation?
     true
   end
+
+  def group_member?(group_id)
+    group_ids.include?(group_id)
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
-  config.hosts << "5e83626a57ba.ngrok.io"
+  config.hosts << "69128d9fd825.ngrok.io"
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.irregular 'cache', 'caches'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   resources :groups, only: [] do
     resources :messages, only: :index
+    resource :message_cache, only: [:create, :show]
     resources :most_liked_messages, only: :index
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   resources :groups, only: [] do
     resources :messages, only: :index
+    resources :most_liked_messages, only: :index
   end
 
   root to: 'application#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   resource :sessions, only: :show
   get 'auth/callback', to: 'sessions#create'
+
+  resources :groups, only: [] do
+    resources :messages, only: :index
+  end
+
   root to: 'application#index'
 end

--- a/db/migrate/20200701135649_create_messages.rb
+++ b/db/migrate/20200701135649_create_messages.rb
@@ -1,0 +1,22 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.references :group, index: true, null: false, foreign_key: true
+
+      t.string :user_id, null: false, index: true
+      t.boolean :system, null: false, index: true, default: false
+
+      t.string :avatar_url
+      t.text :text
+      t.text :favorited_by, null: false, array: true, default: []
+      t.integer :favorites_count, null: false, default: 0
+      t.jsonb :attachments, null: false, default: {}
+      t.json :raw_message, null: false, default: {}
+
+      t.timestamps null: false
+    end
+
+    add_column :users, :group_ids, :text, null: false, array: true, default: []
+    add_column :groups, :messages_last_fetched_at, :datetime
+  end
+end

--- a/db/migrate/20200701175723_create_message_cache.rb
+++ b/db/migrate/20200701175723_create_message_cache.rb
@@ -1,0 +1,13 @@
+class CreateMessageCache < ActiveRecord::Migration[6.0]
+  def change
+    create_table :message_caches do |t|
+      t.timestamp :started_at, null: false, default: -> { 'now()' }
+      t.timestamp :ended_at
+      t.references :group, null: false, index: true, foreign_key: true
+      t.references :started_by, null: false, index: true,
+                                foreign_key: { to_table: 'users' }
+    end
+
+    remove_column :groups, :messages_last_fetched_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_223159) do
+ActiveRecord::Schema.define(version: 2020_07_01_135649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,24 @@ ActiveRecord::Schema.define(version: 2020_06_30_223159) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", null: false
     t.string "image_url"
+    t.datetime "messages_last_fetched_at"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.bigint "group_id", null: false
+    t.string "user_id", null: false
+    t.boolean "system", default: false, null: false
+    t.string "avatar_url"
+    t.text "text"
+    t.text "favorited_by", default: [], null: false, array: true
+    t.integer "favorites_count", default: 0, null: false
+    t.jsonb "attachments", default: {}, null: false
+    t.json "raw_message", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_messages_on_group_id"
+    t.index ["system"], name: "index_messages_on_system"
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -30,8 +48,10 @@ ActiveRecord::Schema.define(version: 2020_06_30_223159) do
     t.string "encrypted_password", limit: 128
     t.string "confirmation_token", limit: 128
     t.string "remember_token", limit: 128
+    t.text "group_ids", default: [], null: false, array: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 
+  add_foreign_key "messages", "groups"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_135649) do
+ActiveRecord::Schema.define(version: 2020_07_01_175723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,15 @@ ActiveRecord::Schema.define(version: 2020_07_01_135649) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", null: false
     t.string "image_url"
-    t.datetime "messages_last_fetched_at"
+  end
+
+  create_table "message_caches", force: :cascade do |t|
+    t.datetime "started_at", default: -> { "now()" }, null: false
+    t.datetime "ended_at"
+    t.bigint "group_id", null: false
+    t.bigint "started_by_id", null: false
+    t.index ["group_id"], name: "index_message_caches_on_group_id"
+    t.index ["started_by_id"], name: "index_message_caches_on_started_by_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -53,5 +61,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_135649) do
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 
+  add_foreign_key "message_caches", "groups"
+  add_foreign_key "message_caches", "users", column: "started_by_id"
   add_foreign_key "messages", "groups"
 end


### PR DESCRIPTION
This PR introduces some changes which lay the foundation for caching
messages in our database. Future work will set up a way to trigger and
managed the message fetching process. We'll likely offload this process
to background job.

There's a new `GroupMe::FetchMessages` class which follows a similar
pattern to the previously added `GroupMe::FetchGroups`. One thing not
yet handled in this new class is how to deal with rate-limiting in the
GroupMe API. We'll probably need to add some pause between pages.

In the migration, we've created a `raw_message` JSON column to store the
raw message data. If we ever want to add new columns to the db, we'll be
able to fetch that information from that JSON column.