### PR TITLE
Introduce MessageCache model and MessageCacheJob

### DIFF
--- a/app/controllers/message_caches_controller.rb
+++ b/app/controllers/message_caches_controller.rb
@@ -1,0 +1,34 @@
+class MessageCachesController < ApplicationController
+  before_action :require_login
+  before_action :require_group_membership
+
+  def show
+    render json: MessageCache.where(group_id: group_id).last
+  end
+
+  def create
+    message_cache = MessageCache.new(
+      started_at: Time.current,
+      group_id: group_id,
+      started_by: current_user
+    )
+
+    if message_cache.save
+      head :ok
+    else
+      render json: message_cache.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def require_group_membership
+    unless current_user.group_member?(group_id)
+      head :unauthorized
+    end
+  end
+
+  def group_id
+    params[:group_id]
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   before_action :require_login
 
   def index
-    if current_user.group_ids.include?(params[:group_id])
+    if current_user.member?(params[:group_id])
       render json: Message.where(group_id: params[:group_id]).limit(20)
     else
       head :unauthorized

--- a/app/jobs/message_cache_job.rb
+++ b/app/jobs/message_cache_job.rb
@@ -2,7 +2,31 @@ class MessageCacheJob < ApplicationJob
   def perform(message_cache_id, access_token)
     message_cache = MessageCache.find(message_cache_id)
     group = message_cache.group
-    GroupMe::FetchMessages.perform(access_token, group.id, group.last_message_id)
+
+    messages = GroupMe::FetchMessages.perform(access_token, group.id, group.last_message_id)
+    insert_messages(messages)
     message_cache.update(ended_at: Time.current)
+  end
+
+  private
+
+  def insert_messages(messages)
+    message_data = messages.map do |message|
+      {
+        id: message.id,
+        group_id: message.group_id,
+        user_id: message.user_id,
+        avatar_url: message.avatar_url,
+        text: message.text,
+        favorited_by: message.favorited_by,
+        favorites_count: message.favorited_by.size,
+        attachments: message.attachments,
+        raw_message: message.data,
+        created_at: Time.at(message.created_at).to_datetime,
+        updated_at: Time.at(message.updated_at).to_datetime
+      }
+
+    end
+    Message.upsert_all(message_data)
   end
 end

--- a/app/jobs/message_cache_job.rb
+++ b/app/jobs/message_cache_job.rb
@@ -1,0 +1,8 @@
+class MessageCacheJob < ApplicationJob
+  def perform(message_cache_id, access_token)
+    message_cache = MessageCache.find(message_cache_id)
+    group = message_cache.group
+    GroupMe::FetchMessages.perform(access_token, group.id, group.last_message_id)
+    message_cache.update(ended_at: Time.current)
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,2 +1,12 @@
 class Group < ApplicationRecord
+  has_many :message_caches
+  has_many :messages
+
+  def last_message_id
+    messages.order(created_at: :desc).first&.id
+  end
+
+  def messages_last_fetched_at
+    message_caches.last&.ended_at
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
+  belongs_to :group
+
   before_save :update_favorites_count
 
   private

--- a/app/models/message_cache.rb
+++ b/app/models/message_cache.rb
@@ -1,0 +1,42 @@
+class MessageCache < ApplicationRecord
+  belongs_to :started_by, class_name: 'User'
+  belongs_to :group
+
+  validates :started_at, :started_by, :group, presence: true
+  validate :start_time_not_in_future
+  validate :end_time_after_start_time
+  validate :one_cache_per_day_per_group, on: :create
+
+  after_create :enqueue_cache_job
+
+  scope :for_last_day, -> { where("started_at >= ?", 24.hours.ago) }
+  scope :running, -> { where(ended_at: nil) }
+
+  def ended?
+    ended_at.present? && ended_at <= Time.current
+  end
+
+  private
+
+  def start_time_not_in_future
+    return if started_at <= Time.current
+
+    errors.add(:started_at, "must be in the past")
+  end
+
+  def end_time_after_start_time
+    return if ended_at.nil? || ended_at > started_at
+
+    errors.add(:ended_at, "must be after started_at")
+  end
+
+  def one_cache_per_day_per_group
+    return unless group.message_caches.for_last_day.exists?
+
+    errors.add(:group, "can only cache messages once per day")
+  end
+
+  def enqueue_cache_job
+    MessageCacheJob.perform_later(id, started_by.access_token)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ApplicationRecord
   def skip_password_validation?
     true
   end
+
+  def group_member?(group_id)
+    group_ids.include?(group_id)
+  end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.irregular 'cache', 'caches'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   resources :groups, only: [] do
     resources :messages, only: :index
+    resource :message_cache, only: [:create, :show]
   end
 
   root to: 'application#index'

--- a/db/migrate/20200701175723_create_message_cache.rb
+++ b/db/migrate/20200701175723_create_message_cache.rb
@@ -1,0 +1,13 @@
+class CreateMessageCache < ActiveRecord::Migration[6.0]
+  def change
+    create_table :message_caches do |t|
+      t.timestamp :started_at, null: false, default: -> { 'now()' }
+      t.timestamp :ended_at
+      t.references :group, null: false, index: true, foreign_key: true
+      t.references :started_by, null: false, index: true,
+                                foreign_key: { to_table: 'users' }
+    end
+
+    remove_column :groups, :messages_last_fetched_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_135649) do
+ActiveRecord::Schema.define(version: 2020_07_01_175723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,15 @@ ActiveRecord::Schema.define(version: 2020_07_01_135649) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", null: false
     t.string "image_url"
-    t.datetime "messages_last_fetched_at"
+  end
+
+  create_table "message_caches", force: :cascade do |t|
+    t.datetime "started_at", default: -> { "now()" }, null: false
+    t.datetime "ended_at"
+    t.bigint "group_id", null: false
+    t.bigint "started_by_id", null: false
+    t.index ["group_id"], name: "index_message_caches_on_group_id"
+    t.index ["started_by_id"], name: "index_message_caches_on_started_by_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -53,5 +61,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_135649) do
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 
+  add_foreign_key "message_caches", "groups"
+  add_foreign_key "message_caches", "users", column: "started_by_id"
   add_foreign_key "messages", "groups"
 end


### PR DESCRIPTION
This PR adds the ability for a user to initialize the caching of
messages from the GroupMe API.

A group can only have one cache job running and can only start one once
every 24 hours. The `MessageCache` model and related table were added
to keep track of when a group's messages are being cached. This new model
renders the `messages_last_cached_at` column on `groups` redundant, so
it was removed.

The GroupMe::FetchGroups class was updated to be able to start fetching
messages from a given message id (`after_id`) if provided. This allows
it to be used for two occasions:
1. No `after_id`: Caching all messages since the start of the group
1. `after_id` provided: Updating cache with new messages since the
   message with the given id was sent

An API endpoint was exposed to kick-off the caching process. It requires
a logged in user who is a member of the group matching the given id.