### PR TITLE
Add 'Show More' button to MostLiked page

### DIFF
--- a/app/controllers/most_liked_messages_controller.rb
+++ b/app/controllers/most_liked_messages_controller.rb
@@ -6,7 +6,13 @@ class MostLikedMessagesController < ApplicationController
   def index
     if current_user.group_member?(group_id)
       limit = params[:limit] || 10
-      messages = Message.where(group_id: group_id).by_favorite_count.limit(limit)
+      offset = params[:offset] || 0
+      messages = Message
+        .where(group_id: group_id)
+        .by_favorite_count
+        .order(created_at: :asc)
+        .offset(offset)
+        .limit(limit)
 
       render json: messages.map(&:serialize)
     else


### PR DESCRIPTION
This commit adds a new button to the bottom of the most liked page that
allows the user to page back through the message history.

When ordering by only `favorites_count`, the results were
non-deterministic. An additional ordering clause (by `created_at`
ascending) was added to keep the ordering of the message list
consistent between pages and refreshes.

![3ZGwDx80u2](https://user-images.githubusercontent.com/11845816/86541644-844ddf80-bedc-11ea-8b94-8ffa4f0ad4bc.gif)
